### PR TITLE
Make event binding optional with submitEvent: false.

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -3203,7 +3203,7 @@ $.fn.jsonFormErrors = function(errors, options) {
  * - displayErrors: Function to call with errors upon form submission.
  *  Default is to render the errors next to the input fields.
  * - submitEvent: Name of the form submission event to bind to.
- *  Default is "submit".
+ *  Default is "submit". Set this option to false to avoid event binding.
  * - onSubmit: Callback function to call when form is submitted
  * - onSubmitValid: Callback function to call when form is submitted without
  *  errors.
@@ -3214,7 +3214,7 @@ $.fn.jsonFormErrors = function(errors, options) {
 $.fn.jsonForm = function(options) {
   var formElt = this;
 
-  options = options || {};
+  options = _.defaults({}, options, {submitEvent: 'submit'});
 
   var form = new formTree();
   form.initialize(options);
@@ -3229,10 +3229,13 @@ $.fn.jsonForm = function(options) {
 
   // Keep a direct pointer to the JSON schema for form submission purpose
   formElt.data("jsonform-tree", form);
-  formElt.unbind((options.submitEvent||'submit')+'.jsonform');
-  formElt.bind((options.submitEvent||'submit')+'.jsonform', function(evt) {
-    form.submit(evt);
-  });
+
+  if (options.submitEvent) {
+    formElt.unbind((options.submitEvent)+'.jsonform');
+    formElt.bind((options.submitEvent)+'.jsonform', function(evt) {
+      form.submit(evt);
+    });
+  }
 
   // Initialize tabs sections, if any
   initializeTabs(formElt);


### PR DESCRIPTION
This allows event binding to be left to a framework like Backbone or rendering of the form into a descendant of the form element.
