### PR TITLE
Missing values from onSubmit output due to serializeArray()

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -2141,8 +2141,14 @@ formNode.prototype.getFormValues = function (updateArrayPath) {
     throw new Error('formNode.getFormValues can only be called on nodes that are associated with a DOM element in the tree');
   }
 
+  // enable disabled inputs because serializeArray() ignores them
+  var disabled = $(this.el).find(':input:disabled').removeAttr('disabled');
+
   // Form fields values
   var formArray = $(':input', this.el).serializeArray();
+
+  // re-disable disabled fields
+  disabled.attr('disabled','disabled');
 
   // Set values to false for unset checkboxes and radio buttons
   // because serializeArray() ignores them


### PR DESCRIPTION
1. unset checkboxes and radio boxes are left out of the output instead of being set to false
2. disabled inputs are left out of the output instead of being set
