### PR TITLE
Fix for Issue #52: A zero in the value can't be rendered.

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -2116,7 +2116,7 @@ formNode.prototype.computeInitialValues = function (values, ignoreDefaultValues)
       // Form has already been submitted, use former value if defined.
       // Note we won't set the field to its default value otherwise
       // (since the user has already rejected it)
-      if (jsonform.util.getObjKey(values, this.key)) {
+      if (isSet(jsonform.util.getObjKey(values, this.key))) {
         this.value = jsonform.util.getObjKey(values, this.key);
       }
     }


### PR DESCRIPTION
This simple change fixes issue #52. Predefined (as in when the form is submitted) zero values were being ignored due to an if statement that potentially returned an integer being evaluated as a boolean expression. This line now calls `ifSet` to check for undefined values.
