### PR TITLE
Added Space to jQuery Escape Selector

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -93,7 +93,7 @@
  * @return {String} The escaped selector.
  */
 var escapeSelector = function (selector) {
-  return selector.replace(/([\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;<\=\>\?\@\[\\\]\^\`\{\|\}\~])/g, '\\$1');
+  return selector.replace(/([ \!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;<\=\>\?\@\[\\\]\^\`\{\|\}\~])/g, '\\$1');
 };
 
 


### PR DESCRIPTION
http://api.jquery.com/category/selectors/ indicates that space is a valid meta-
character.

The symptom of this problem was the add and remove buttons of an array did not work when the array key had spaces in it. Spaces in the div id were not getting escaped for jQuery. Even though spaces in the div id are not technically valid, this fixes the problem and the escape function now does all of the meta-characters as advertised.
