### PR TITLE
Fix for multidimensional arrays.

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -1461,9 +1461,12 @@ jsonform.util.setObjKey = function(obj,key,value) {
  * @return {Object} The key definition in the schema, null if not found.
  */
 var getSchemaKey = function(schema,key) {
-  var schemaKey = key
-    .replace(/\./g, '.properties.')
-    .replace(/\[[0-9]*\](\.|$)/g, '.items$1');
+  var schemaKey = key.replace(/\./g, '.properties.');
+  do {
+      var previousSchemaKey = schemaKey;
+      schemaKey = schemaKey.replace(/\[[0-9]*\](\.|$)/g, '.items$1');
+  }
+  while (schemaKey != previousSchemaKey);
   var schemaDef = jsonform.util.getObjKey(schema, schemaKey, true);
   if (schemaDef && schemaDef.$ref) {
     throw new Error('JSONForm does not yet support schemas that use the ' +


### PR DESCRIPTION
getSchemaKey did a single replace of "[]" with ".items". When searching for "blah[][]", the result was "blah[].items" and needed to be "blah.items.items". The methond now iteratively replaces each instance of "[]" with ".items".
