### PR TITLE
Added all available modes to playground

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -118,6 +118,11 @@
     <script src="../deps/opt/spectrum.js"></script>
     <script src="../deps/opt/ace/ace.js"></script>
     <script src="../deps/opt/ace/mode-json.js"></script>
+    <script src="../deps/opt/ace/mode-html.js"></script>
+    <script src="../deps/opt/ace/mode-css.js"></script>
+    <script src="../deps/opt/ace/mode-javascript.js"></script>
+    <script src="../deps/opt/ace/mode-less.js"></script>
+    <script src="../deps/opt/ace/mode-markdown.js"></script>
     <script src="../deps/opt/jquery.transloadit2.js"></script>
 
     <script src="../lib/jsonform.js"></script>


### PR DESCRIPTION
Some of the available modes (html, css, javascript, less, and markdown) were not available for use in playground. The solution is to add them to playground/index.html.
