### PR TITLE
Now the readonly property of fields is read from schemaElement. JsonSche...

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -235,7 +235,7 @@ var inputFieldTemplate = function (type) {
       '<%= (fieldHtmlClass ? "class=\'" + fieldHtmlClass + "\' " : "") %>' +
       'name="<%= node.name %>" value="<%= escape(value) %>" id="<%= id %>"' +
       '<%= (node.disabled? " disabled" : "")%>' +
-      '<%= (node.formElement && node.formElement.readonly ? " readonly=\'readonly\'" : "") %>' +
+      '<%= (node.formElement && node.schemaElement.readonly ? " readonly=\'readonly\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.maxLength ? " maxlength=\'" + node.schemaElement.maxLength + "\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.required && (node.schemaElement.type !== "boolean") ? " required=\'required\'" : "") %>' +
       '<%= (node.placeholder? "placeholder=" + \'"\' + escape(node.placeholder) + \'"\' : "")%>' +


### PR DESCRIPTION
JSON Schema already supports a property called `readonly`.
We should be looking to change a field to read-only by looking the schema and not the form-customization.

Here is where the JSON Schema spec define the property:
http://json-schema.org/latest/json-schema-hypermedia.html#anchor15
