### PR TITLE
Allow minItems 0 to work for tabarray and array components

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -1049,8 +1049,8 @@ jsonform.elementTypes = {
       }
 
       // Simulate User's click to setup the form with its minItems
-      if (boundaries.minItems >= 0) {
-        for (var i = 0; i < (boundaries.minItems); i++) {
+      if (boundaries.minItems >= 0 && node.children.length < boundaries.minItems) {
+        for (var i = 0; i < (boundaries.minItems - 1); i++) {
           $nodeid.find('> a._jsonform-array-addmore').click();
         }
         $nodeid.find('> a._jsonform-array-deleteitem').addClass('disabled');

--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -3576,13 +3576,9 @@ $.fn.jsonFormValue = function() {
 
 // Expose the getFormValue method to the global object
 // (other methods exposed as jQuery functions)
-global.JSONForm = global.JSONForm || {util:{}};
-global.JSONForm.getFormValue = jsonform.getFormValue;
-global.JSONForm.fieldTemplate = jsonform.fieldTemplate;
-global.JSONForm.fieldTypes = jsonform.elementTypes;
-global.JSONForm.getInitialValue = getInitialValue;
-global.JSONForm.util.getObjKey = jsonform.util.getObjKey;
-global.JSONForm.util.setObjKey = jsonform.util.setObjKey;
+if (!global.JSONForm) {
+  global.JSONForm = jsonform;
+}
 
 })((typeof exports !== 'undefined'),
   ((typeof exports !== 'undefined') ? exports : window),

--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -412,7 +412,7 @@ jsonform.elementTypes = {
           $(node.el).find(idSelector).change();
         }, 600);
         editor.getSession().on('change', lazyChanged);
-        
+
         editor.on('blur', function() {
           $(node.el).find(idSelector).change();
           $(node.el).find(idSelector).trigger("blur");
@@ -471,7 +471,7 @@ jsonform.elementTypes = {
       } else {
         node.ownerTree._transloadit_generic_public_index++;
       }
-      
+
       data.transloaditname = "_transloadit_jsonform_genericupload_public_"+node.ownerTree._transloadit_generic_public_index;
 
       if (!node.ownerTree._transloadit_generic_elts) node.ownerTree._transloadit_generic_elts = {};
@@ -850,7 +850,7 @@ jsonform.elementTypes = {
       var curItems = $('> ul > li', $nodeid).length;
       if ((boundaries.minItems > 0) &&
           (curItems < boundaries.minItems)) {
-        for (var i = 0; i < (boundaries.minItems - 1) && ($nodeid.find('> ul > li').length < boundaries.minItems); i++) {
+        for (var i = 0; i < (boundaries.minItems) && ($nodeid.find('> ul > li').length < boundaries.minItems); i++) {
           //console.log('Calling click: ',$nodeid);
           //$('> span > a._jsonform-array-addmore', $nodeid).click();
           node.insertArrayItem(curItems, $nodeid.find('> ul').get(0));
@@ -1050,7 +1050,7 @@ jsonform.elementTypes = {
 
       // Simulate User's click to setup the form with its minItems
       if (boundaries.minItems >= 0) {
-        for (var i = 0; i < (boundaries.minItems - 1); i++) {
+        for (var i = 0; i < (boundaries.minItems); i++) {
           $nodeid.find('> a._jsonform-array-addmore').click();
         }
         $nodeid.find('> a._jsonform-array-deleteitem').addClass('disabled');
@@ -1828,7 +1828,7 @@ formNode.prototype.hasNonDefaultValue = function () {
   if (this.formElement && this.formElement.type=="hidden") {
     return false;
   }
-  
+
   if (this.value && !this.defaultValue) {
     return true;
   }
@@ -2197,6 +2197,8 @@ formNode.prototype.computeInitialValues = function (values, ignoreDefaultValues)
   }
   else if (this.view && this.view.array) {
     // Case 2: array-like node
+    var minItems = this.getArrayBoundaries().minItems;
+
     nbChildren = 0;
     if (values) {
       nbChildren = this.getPreviousNumberOfItems(values, this.arrayPath);
@@ -2211,7 +2213,7 @@ formNode.prototype.computeInitialValues = function (values, ignoreDefaultValues)
       nbChildren = this.schemaElement['default'].length;
     }
     */
-    else if (nbChildren === 0) {
+    else if (minItems < 0) {
       // If form has already been submitted with no children, the array
       // needs to be rendered without children. If there are no previously
       // submitted values, the array gets rendered with one empty item as
@@ -2219,6 +2221,7 @@ formNode.prototype.computeInitialValues = function (values, ignoreDefaultValues)
       // be removed with a click on the "-" button.
       nbChildren = 1;
     }
+
     for (i = 0; i < nbChildren; i++) {
       this.appendChild(this.childTemplate.clone());
     }
@@ -2841,7 +2844,7 @@ formNode.prototype.getArrayBoundaries = function () {
       );
       if (!schemaKey) return boundaries;
       return {
-        minItems: schemaKey.minItems || schemaKey.minLength || -1,
+        minItems: (schemaKey.minItems >= 0) ? schemaKey.minItems : (schemaKey.minLength || -1),
         maxItems: schemaKey.maxItems || schemaKey.maxLength || -1
       };
     }
@@ -3154,7 +3157,7 @@ formTree.prototype.buildFromLayout = function (formElement, context) {
     throw new Error('The JSONForm contains an element whose type is unknown: "' +
       formElement.type + '"');
   }
-  
+
 
   if (schemaElement) {
     // The form element is linked to an element in the schema.
@@ -3279,7 +3282,7 @@ formTree.prototype.render = function (domRoot) {
  * @param {Function} callback The callback to call on each element
  */
 formTree.prototype.forEachElement = function (callback) {
-  
+
   var f = function(root) {
     for (var i=0;i<root.children.length;i++) {
       callback(root.children[i]);

--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -397,8 +397,7 @@ jsonform.elementTypes = {
         editor.setTheme("ace/theme/"+(formElement.aceTheme||"twilight"));
 
         if (formElement.aceMode) {
-          var mode = ace.require("ace/mode/"+formElement.aceMode).Mode;
-          editor.getSession().setMode(new mode());
+          editor.getSession().setMode("ace/mode/"+formElement.aceMode);
         }
         editor.getSession().setTabSize(2);
 

--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -3085,7 +3085,11 @@ formTree.prototype.buildFromLayout = function (formElement, context) {
       } else if (schemaElement.type === 'boolean') {
         formElement.type = 'checkbox';
       } else if (schemaElement.type === 'object') {
-        formElement.type = 'fieldset';
+        if (schemaElement.properties) {
+          formElement.type = 'fieldset';
+        } else {
+          formElement.type = 'textarea';
+        }
       } else if (!_.isUndefined(schemaElement['enum'])) {
         formElement.type = 'select';
       } else {

--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -2219,7 +2219,7 @@ formNode.prototype.computeInitialValues = function (values, ignoreDefaultValues)
       // submitted values, the array gets rendered with one empty item as
       // it's more natural from a user experience perspective. That item can
       // be removed with a click on the "-" button.
-      if (minItems === 0) {
+      if (minItems >= 0) {
         nbChildren = 0;
       }
 

--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -2810,6 +2810,7 @@ formNode.prototype.getArrayBoundaries = function () {
 
   var getNodeBoundaries = function (node, initialNode) {
     var schemaKey = null;
+    var arrayKey = null;
     var boundaries = {
       minItems: -1,
       maxItems: -1
@@ -2824,13 +2825,19 @@ formNode.prototype.getArrayBoundaries = function () {
 
     if (node.key) {
       // Note the conversion to target the actual array definition in the
-      // schema where minItems/maxItems may be defined,
-      // e.g. from foo[0].bar[3].baz to foo[].bar
+      // schema where minItems/maxItems may be defined. If we're still looking
+      // at the initial node, the goal is to convert from:
+      //  foo[0].bar[3].baz to foo[].bar[].baz
+      // If we're not looking at the initial node, the goal is to look at the
+      // closest array parent:
+      //  foo[0].bar[3].baz to foo[].bar
+      arrayKey = node.key.replace(/\[[0-9]+\]/g, '[]');
+      if (node !== initialNode) {
+        arrayKey = arrayKey.replace(/\[\][^\[\]]*$/, '');
+      }
       schemaKey = getSchemaKey(
         node.ownerTree.formDesc.schema.properties,
-        node.key
-          .replace(/\[[0-9]+\]/g, '[]')
-          .replace(/\[\][^\[\]]*$/, '')
+        arrayKey
       );
       if (!schemaKey) return boundaries;
       return {


### PR DESCRIPTION
The change we made was allow `minItems: 0` to work properly.

When using tabarray or array components, JsonForm will create a empty child if none is present on data(value).

Given the following schema:

```
{
  "schema": {
    "friends": {
      "type": "array",
      "items": {
        "type": "object",
        "title": "Friend",
        "properties": {
          "nick": {
            "type": "string",
            "title": "Nickname",
            "required": true
          }
        }
      }
    }
  }
}
```

You can have no friends, but if you have one, they must have a nickname.
So, if one child is create if none is present, it kind of forces users to fill the friend's nickname.
Setting `minItems: 0` solve this problem.
