### PR TITLE
Solve problems when exposing global. Fix also problems when extending templates

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -3573,13 +3573,9 @@ $.fn.jsonFormValue = function() {
 
 // Expose the getFormValue method to the global object
 // (other methods exposed as jQuery functions)
-global.JSONForm = global.JSONForm || {util:{}};
-global.JSONForm.getFormValue = jsonform.getFormValue;
-global.JSONForm.fieldTemplate = jsonform.fieldTemplate;
-global.JSONForm.fieldTypes = jsonform.elementTypes;
-global.JSONForm.getInitialValue = getInitialValue;
-global.JSONForm.util.getObjKey = jsonform.util.getObjKey;
-global.JSONForm.util.setObjKey = jsonform.util.setObjKey;
+if (!global.JSONForm) {
+  global.JSONForm = jsonform;
+}
 
 })((typeof exports !== 'undefined'),
   ((typeof exports !== 'undefined') ? exports : window),

--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -412,7 +412,7 @@ jsonform.elementTypes = {
           $(node.el).find(idSelector).change();
         }, 600);
         editor.getSession().on('change', lazyChanged);
-        
+
         editor.on('blur', function() {
           $(node.el).find(idSelector).change();
           $(node.el).find(idSelector).trigger("blur");
@@ -471,7 +471,7 @@ jsonform.elementTypes = {
       } else {
         node.ownerTree._transloadit_generic_public_index++;
       }
-      
+
       data.transloaditname = "_transloadit_jsonform_genericupload_public_"+node.ownerTree._transloadit_generic_public_index;
 
       if (!node.ownerTree._transloadit_generic_elts) node.ownerTree._transloadit_generic_elts = {};
@@ -839,7 +839,7 @@ jsonform.elementTypes = {
         }
         node.insertArrayItem(idx, $('> ul', $nodeid).get(0));
         if ((boundaries.minItems <= 0) ||
-            ((boundaries.minItems > 0) &&
+            ((boundaries.minItems >= 0) &&
               (node.children.length > boundaries.minItems - 1))) {
           $nodeid.find('> span > a._jsonform-array-deletelast')
             .removeClass('disabled');
@@ -856,7 +856,7 @@ jsonform.elementTypes = {
           node.insertArrayItem(curItems, $nodeid.find('> ul').get(0));
         }
       }
-      if ((boundaries.minItems > 0) &&
+      if ((boundaries.minItems >= 0) &&
           (node.children.length <= boundaries.minItems)) {
         $nodeid.find('> span > a._jsonform-array-deletelast')
           .addClass('disabled');
@@ -1828,7 +1828,7 @@ formNode.prototype.hasNonDefaultValue = function () {
   if (this.formElement && this.formElement.type=="hidden") {
     return false;
   }
-  
+
   if (this.value && !this.defaultValue) {
     return true;
   }
@@ -2197,7 +2197,9 @@ formNode.prototype.computeInitialValues = function (values, ignoreDefaultValues)
   }
   else if (this.view && this.view.array) {
     // Case 2: array-like node
-    nbChildren = 0;
+    nbChildren = 1;
+    var minItems = this.getArrayBoundaries().minItems;
+
     if (values) {
       nbChildren = this.getPreviousNumberOfItems(values, this.arrayPath);
     }
@@ -2211,14 +2213,18 @@ formNode.prototype.computeInitialValues = function (values, ignoreDefaultValues)
       nbChildren = this.schemaElement['default'].length;
     }
     */
-    else if (nbChildren === 0) {
+    else {
       // If form has already been submitted with no children, the array
       // needs to be rendered without children. If there are no previously
       // submitted values, the array gets rendered with one empty item as
       // it's more natural from a user experience perspective. That item can
       // be removed with a click on the "-" button.
-      nbChildren = 1;
+      if (minItems === 0) {
+        nbChildren = 0;
+      }
+
     }
+
     for (i = 0; i < nbChildren; i++) {
       this.appendChild(this.childTemplate.clone());
     }
@@ -2806,6 +2812,7 @@ formNode.prototype.getArrayBoundaries = function () {
     minItems: -1,
     maxItems: -1
   };
+
   if (!this.view || !this.view.array) return boundaries;
 
   var getNodeBoundaries = function (node, initialNode) {
@@ -2840,10 +2847,24 @@ formNode.prototype.getArrayBoundaries = function () {
         arrayKey
       );
       if (!schemaKey) return boundaries;
-      return {
-        minItems: schemaKey.minItems || schemaKey.minLength || -1,
-        maxItems: schemaKey.maxItems || schemaKey.maxLength || -1
-      };
+
+      if (schemaKey.minItems >= 0) {
+        boundaries.minItems = schemaKey.minItems;
+      }
+
+      if (schemaKey.minLength >= 0) {
+        boundaries.minItems = schemaKey.minLength;
+      }
+
+      if (schemaKey.maxItems >= 0) {
+        boundaries.maxItems = schemaKey.maxItems;
+      }
+
+      if (schemaKey.maxLength >= 0) {
+        boundaries.maxItems = schemaKey.maxLength;
+      }
+
+      return boundaries;
     }
     else {
       _.each(node.children, function (child) {
@@ -3154,7 +3175,7 @@ formTree.prototype.buildFromLayout = function (formElement, context) {
     throw new Error('The JSONForm contains an element whose type is unknown: "' +
       formElement.type + '"');
   }
-  
+
 
   if (schemaElement) {
     // The form element is linked to an element in the schema.
@@ -3279,7 +3300,7 @@ formTree.prototype.render = function (domRoot) {
  * @param {Function} callback The callback to call on each element
  */
 formTree.prototype.forEachElement = function (callback) {
-  
+
   var f = function(root) {
     for (var i=0;i<root.children.length;i++) {
       callback(root.children[i]);


### PR DESCRIPTION
`fieldTemplate` is a function and when replaced outside of local scope, its reference is changed not allowing me to extend template behavior.

```
// Local scope
global.JSONForm.fieldTemplate = jsonform.fieldTemplate;

// Global scope
JSONForm.fieldTemplate = function() {};
```
