### PR TITLE
Fix IE8 array value retrieval

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -1356,6 +1356,7 @@ jsonform.util.getObjKey = function (obj, key, ignoreArrays) {
     if ((innerobj === null) || (typeof innerobj !== "object")) return null;
     subkey = keyparts[i];
     prop = subkey.replace(reArray, '');
+    reArray.lastIndex = 0;
     arrayMatch = reArray.exec(subkey);
     if (arrayMatch) {
       while (true) {
@@ -1410,6 +1411,7 @@ jsonform.util.setObjKey = function(obj,key,value) {
   for (var i = 0; i < keyparts.length-1; i++) {
     subkey = keyparts[i];
     prop = subkey.replace(reArray, '');
+    reArray.lastIndex = 0;
     arrayMatch = reArray.exec(subkey);
     if (arrayMatch) {
       // Subkey is part of an array
@@ -1441,6 +1443,7 @@ jsonform.util.setObjKey = function(obj,key,value) {
   // Set the final value
   subkey = keyparts[keyparts.length - 1];
   prop = subkey.replace(reArray, '');
+  reArray.lastIndex = 0;
   arrayMatch = reArray.exec(subkey);
   if (arrayMatch) {
     while (true) {


### PR DESCRIPTION
In IE8 `subkey.replace(reArray, '');` increments `reArray.lastIndex` so the next call to exec fails to match array.
