### PR TITLE
add multiple select support

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -615,12 +615,12 @@ jsonform.elementTypes = {
     }
   },
   'select':{
-    'template':'<select name="<%= node.name %>" id="<%= id %>"' +
+    'template':'<select name="<%= node.name %><%= (node.schemaElement && node.schemaElement.multiple ? "[]" : "") %>" id="<%= id %>"' +
       '<%= (fieldHtmlClass ? " class=\'" + fieldHtmlClass + "\'" : "") %>' +
       '<%= (node.disabled? " disabled" : "")%>' +
       '<%= (node.schemaElement && node.schemaElement.required ? " required=\'required\'" : "") %>' +
       '> ' +
-      '<% _.each(node.options, function(key, val) { if(key instanceof Object) { if (value === key.value) { %> <option selected value="<%= key.value %>"><%= key.title %></option> <% } else { %> <option value="<%= key.value %>"><%= key.title %></option> <% }} else { if (value === key) { %> <option selected value="<%= key %>"><%= key %></option> <% } else { %><option value="<%= key %>"><%= key %></option> <% }}}); %> ' +
+      '<% _.each(node.options, function(key, val) { if(key instanceof Object) { if (value === key.value) { %> <option selected value="<%= key.value %>"><%= key.title %></option> <% } else { %> <option value="<%= key.value %>"><%= key.title %></option> <% }} else { if (value === key) { %> <option selected value="<%= key %>"><%= key %></option> <% } else { if ( node.in_array(key, node.schemaElement.default)) { %> <option selected value="<%= key %>"><%= key %></option> <% } else { %><option value="<%= key %>"><%= key %></option> <% }}}}); %> ' +
       '</select>',
     'fieldtemplate': true,
     'inputfield': true
@@ -3191,7 +3191,16 @@ formTree.prototype.buildFromLayout = function (formElement, context) {
   node.schemaElement = schemaElement;
   node.view = view;
   node.ownerTree = this;
-
+  node.in_array = function in_array(needle, haystack, strict) { 
+        var found = false, key, strict = !!strict;
+        for (key in haystack) {
+            if ((strict && haystack[key] === needle) || (!strict && haystack[key] == needle)) {
+                found = true;
+                break;
+            }
+        }
+        return found;
+    }
   // Set event handlers
   if (!formElement.handlers) {
     formElement.handlers = {};


### PR DESCRIPTION
```
multiple_select_field: {
    type: 'string',
    title: 'test multiple',
    multiple: true,
    default: ['a','b'],
    enum: ['a','b','c','d','e']
}
```

I implemented a small ability to multi select field. maybe I did not properly use the default value? I'm putting out there saved data from db json... but for me it works. I think that features may be interesting for someone, how do you think?
