### PR TITLE
textarea misses fieldHtmlClass option

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -323,6 +323,7 @@ jsonform.elementTypes = {
   },
   'textarea':{
     'template':'<textarea id="<%= id %>" name="<%= node.name %>" ' +
+      '<%= (fieldHtmlClass ? "class=\'" + fieldHtmlClass + "\' " : "") %>' +
       'style="height:<%= elt.height || "150px" %>;width:<%= elt.width || "100%" %>;"' +
       '<%= (node.disabled? " disabled" : "")%>' +
       '<%= (node.readOnly ? " readonly=\'readonly\'" : "") %>' +
@@ -335,6 +336,7 @@ jsonform.elementTypes = {
   },
   'wysihtml5':{
     'template':'<textarea id="<%= id %>" name="<%= node.name %>" style="height:<%= elt.height || "300px" %>;width:<%= elt.width || "100%" %>;"' +
+      '<%= (fieldHtmlClass ? "class=\'" + fieldHtmlClass + "\' " : "") %>' +
       '<%= (node.disabled? " disabled" : "")%>' +
       '<%= (node.readOnly ? " readonly=\'readonly\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.maxLength ? " maxlength=\'" + node.schemaElement.maxLength + "\'" : "") %>' +


### PR DESCRIPTION
Hello there and thank you for your library.

I started using this quite heavily and I've found that I couldn't add a class to a text area using the json descriptor.
