### PR TITLE
Added support for a htmlMetaData form property.  This property can be…

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -196,7 +196,14 @@ var initializeTabs = function (tabs) {
 
 // Twitter bootstrap-friendly HTML boilerplate for standard inputs
 jsonform.fieldTemplate = function(inner) {
-  return '<div class="form-group jsonform-error-<%= keydash %>' +
+  return '<div ' +
+    '<% for(var key in elt.htmlMetaData) {%>' +
+      '<%= key %>' +
+      '=" ' +
+      '<%= elt.htmlMetaData[key] %>' +
+      '" ' +
+    '<% }%>' +
+    'class="form-group jsonform-error-<%= keydash %>' +
     '<%= elt.htmlClass ? " " + elt.htmlClass : "" %>' +
     '<%= (node.schemaElement && node.schemaElement.required && (node.schemaElement.type !== "boolean") ? " jsonform-required" : "") %>' +
     '<%= (node.readOnly ? " jsonform-readonly" : "") %>' +


### PR DESCRIPTION
… used to add additonal html metadata. The property should be specified as a hashmap. For example - form = [{"key": "myInput", "htmlMetaData": {"title": "tooltip", "style":"color: red"} this will add a tooltip and change the color of myInput