### PR TITLE
Fix issue with "disabled" attribute not being correctly handled for select items

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -627,7 +627,7 @@ jsonform.elementTypes = {
   'select':{
     'template':'<select name="<%= node.name %>" id="<%= id %>"' +
       'class=\'form-control<%= (fieldHtmlClass ? " " + fieldHtmlClass : "") %>\'' +
-      '<%= (node.disabled? " disabled" : "")%>' +
+      '<%= (node.schemaElement && node.schemaElement.disabled? " disabled" : "")%>' +
       '<%= (node.schemaElement && node.schemaElement.required ? " required=\'required\'" : "") %>' +
       '> ' +
       '<% _.each(node.options, function(key, val) { if(key instanceof Object) { if (value === key.value) { %> <option selected value="<%= key.value %>"><%= key.title %></option> <% } else { %> <option value="<%= key.value %>"><%= key.title %></option> <% }} else { if (value === key) { %> <option selected value="<%= key %>"><%= key %></option> <% } else { %><option value="<%= key %>"><%= key %></option> <% }}}); %> ' +


### PR DESCRIPTION
When rendering a form for review purposes, I noted that the select objects were not being disabled even though the correct json for it to be disabled was passed to the generator.

Simple fix to resolve the issue is attached