### PR TITLE
Update jsonform.js to allow numbers with decimals by setting the step

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -247,6 +247,7 @@ var inputFieldTemplate = function (type) {
       'name="<%= node.name %>" value="<%= escape(value) %>" id="<%= id %>"' +
       '<%= (node.disabled? " disabled" : "")%>' +
       '<%= (node.readOnly ? " readonly=\'readonly\'" : "") %>' +
+      '<%= (node.schemaElement.step > 0 ? " step='" + node.schemaElement.step + "'" : "")%>' +
       '<%= (node.schemaElement && node.schemaElement.maxLength ? " maxlength=\'" + node.schemaElement.maxLength + "\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.required && (node.schemaElement.type !== "boolean") ? " required=\'required\'" : "") %>' +
       '<%= (node.placeholder? " placeholder=" + \'"\' + escape(node.placeholder) + \'"\' : "")%>' +


### PR DESCRIPTION
Added the ability to allow numbers with decimals by retrieving the step field in the schema.
In the schema for the type that allows decimals, add "step" and set what the decimal format should be. This will enforce how it increments and how many values after the decimal are allowed. An example schema is below:

"field2": {
"type": "number",
"title": "A Number Field",
"step": 0.01
}