### PR TITLE
Legend to show enum values

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -2807,17 +2807,19 @@ formNode.prototype.enhance = function () {
 
     // Auto-update legend based on the input field that's associated with it
     if (this.legendChild && this.legendChild.formElement) {
-      $(this.legendChild.el).bind('keyup', function (evt) {
-        if (node.formElement && node.formElement.legend && node.parentNode) {
-          node.legend = applyArrayPath(node.formElement.legend, node.arrayPath);
-          formData.idx = (node.arrayPath.length > 0) ?
-            node.arrayPath[node.arrayPath.length-1] + 1 :
-            node.childPos + 1;
-          formData.value = $(evt.target).val();
-          node.legend = _.template(node.legend, valueTemplateSettings)(formData);
-          $(node.parentNode.el).trigger('legendUpdated');
-        }
-      });
+      var onChangeHandler = function (evt) {
+              if (node.formElement && node.formElement.legend && node.parentNode) {
+                  node.legend = applyArrayPath(node.formElement.legend, node.arrayPath);
+                  formData.idx = (node.arrayPath.length > 0) ?
+                      node.arrayPath[node.arrayPath.length - 1] + 1 :
+                      node.childPos + 1;
+                  formData.value = $(evt.target).val();
+                  node.legend = _.template(node.legend, valueTemplateSettings)(formData);
+                  $(node.parentNode.el).trigger('legendUpdated');
+              }
+          };
+          $(this.legendChild.el).bind('change', onChangeHandler);
+          $(this.legendChild.el).bind('keyup', onChangeHandler);
     }
   }
 


### PR DESCRIPTION
Updated the binding of changes when using a legend. Changes were not reflected when the text field was using an enum unless you used they keyboard to scroll through the different options. Below is a sample form that has a legend with an array and text enum. Verified this works with an existing legend that is tied to a standard text box.

```
{
	"schema": {
	    "coverages":
	    {
	        "type":"array",
	        "items":{
				"type": "object",
				"title":"Max Coverage",
				"properties": {
					"name":{
						"type":"string",
						"title":"Coverage Name",
						"required":true,
						"enum":["","NPPA","MDDO","Scribe"]
					},
					"hours": {
						"type": "number",
						"title": "Coverage (Hours)",
						"required":true,
						"step":1
					}
				}				
	        }
		}		
	},
	"form": [
		{
		  "type": "tabarray",
		  "items": {
			"type": "section",
			"legend":"{{value}}",
			"items": [
				{
				  "key": "coverages[].name",
				  "title": "Coverage Name",
				  "valueInLegend": true
				},
				"coverages[].hours",
				{
      "type": "submit",
      "title": "Submit"
    } 
			]
		  }
		}
	]
}
```