### PR TITLE
Allow number type fields to accept decimal numbers

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -3217,6 +3217,7 @@ formTree.prototype.buildFromLayout = function (formElement, context) {
         schemaElement.type === 'integer') &&
         !schemaElement['enum']) {
        formElement.type = 'number';
+       if (schemaElement.type === 'number') schemaElement.step = 'any';
       } else if ((schemaElement.type === 'string' ||
         schemaElement.type === 'any') &&
         !schemaElement['enum']) {


### PR DESCRIPTION
At the moment 'number' and 'integer' types are both creating fields that only accept integers. 

According to the documentation, the intention of 'number' is to accept floating numbers as well:
https://github.com/jsonform/jsonform/wiki#supported-types

This behaviour was broken in this recent commit:
https://github.com/jsonform/jsonform/commit/b43b465da030f0ba1607924b77ddc44496c24242

The proposed change makes 'number' type fields accept decimal numbers again.