### PR TITLE
user can now remove items if minItem is set

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -1140,7 +1140,8 @@ jsonform.elementTypes = {
       }
 
       // Simulate User's click to setup the form with its minItems
-      if (boundaries.minItems >= 0) {
+      if ((boundaries.minItems >= 0)  && 
+          (node.children.length <= boundaries.minItems)) {
         for (var i = 0; i < (boundaries.minItems - 1); i++) {
           $nodeid.find('> a._jsonform-array-addmore').click();
         }


### PR DESCRIPTION
Fixed a bug where when editing a jsonform with an array type, if the minItems was set and the initial node.children.length >= minItems, it did not allow the user to remove from that array.