### PR TITLE
Fix selectfieldset behaviour

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -1291,6 +1291,7 @@ jsonform.elementTypes = {
       }
       else {
         children = _.map(node.children, function (child, idx) {
+          child.childPos = idx; // When nested the childPos is always 0.
           return {
             title: child.legend || child.title || ('Option ' + (child.childPos+1)),
             value: choices[child.childPos] || child.childPos,


### PR DESCRIPTION
When used in an `array` or  `tabarray`, selectfieldset is buggy.