### PR TITLE
Context error in formNode.prototype.updateElement

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -2667,9 +2667,9 @@ formNode.prototype.updateElement = function (domNode) {
     }
   }
 
-  _.each(this.children, function (child) {
-    child.updateElement(this.el || domNode);
-  });
+  for(var k in this.children) {
+    this.children[k].updateElement(this.el || domNode);
+  }
 };
 
 


### PR DESCRIPTION


when using "this" inside a _.each() loop "this" refers to the Window variable
in some cases this.el might be set with an element which then is forwardet to updateElement()
this leads to an error
![window](https://user-images.githubusercontent.com/6481463/93199698-f8afc500-f74e-11ea-9b4c-db6b7a4c6aa6.jpg)
