### PR TITLE
feat: Add navigation tabs

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -1225,6 +1225,50 @@ jsonform.elementTypes = {
     'template':'<input type="hidden" id="<%= id %>" name="<%= node.name %>" value="<%= escape(value) %>" />',
     'inputfield': true
   },
+  'tabs':{
+    'template':'<ul class="nav nav-tabs <%= elt.htmlClass?elt.htmlClass:"" %>"' + 
+    '<% if (elt.id) { %> id="<%= elt.id %>"<% } %>' +
+    '><%=tab_list%></ul><div class="tab-content" <% if (elt.id) { %> data-tabset="<%= elt.id %>"<% } %>><%=children%></div>',
+    'getElement': function (el) {
+      return $(el).parent().get(0);
+    },
+    'onBeforeRender': function (data, node) {
+      // Generate the initial 'tabs' from the children
+      var parentID = escapeHTML(node.id ? node.id + "-" : "") 
+      var tab_list = '';
+      _.each(node.children, function (child, idx) {
+        var title = escapeHTML(child.title || ('Item ' + (idx+1)));
+        var title_escaped = title.replace(" ","_");
+        tab_list += '<li class="nav-item' +
+          ((idx === 0) ? ' active' : '') + '">' +
+          '<a href="#'+ parentID + title_escaped +'" class="nav-link"' +
+          ' data-tab="' + parentID + title_escaped + '"' + 
+          ' data-toggle="tab">' + title +
+          '</a></li>';
+      });
+      data.tab_list = tab_list;
+      return data;
+    },
+    'onInsert': function(evt, node){
+      $("#"+node.id+">li.nav-item").on("click", function(e){
+        e.preventDefault();
+        $(node.el).find("div[data-tabset='"+node.id+"']>div.tab-pane.active").each(function(){
+          $(this).removeClass("active"); 
+        })
+        var tab_id = $(this).find('a').attr('data-tab');
+        $("#"+tab_id).addClass("active");
+      });
+    }
+  },
+  'tab':{
+    'template': '<div class="tab-pane' +
+    '<% if (elt.htmlClass) { %> <%= elt.htmlClass %> <% } %>' +
+        //Set the first tab as active
+    '<% if (node.childPos === 0) { %> active<% } %>' +
+    '"' + //Finish end quote of class tag
+    '<% if (node.title) { %> id="<%= node.parentNode.id %>-<%= node.title.replace(" ","_") %>"<% } %>' +
+    '><%= children %></div>'
+  },
   'selectfieldset': {
     'template': '<fieldset class="tab-container <%= elt.htmlClass?elt.htmlClass:"" %>">' +
       '<% if (node.legend) { %><legend><%= node.legend %></legend><% } %>' +

--- a/playground/examples/navigation-tabs.json
+++ b/playground/examples/navigation-tabs.json
@@ -1,0 +1,107 @@
+{
+    "schema": {
+        "favorite_movie":{
+          "type":"string",
+          "title":"Favorite Movie",
+          "enum":[
+            "Field of Dreams",
+            "Braveheart",
+            "A League of Their Own"
+          ]
+        },
+        "favorite_tv":{
+          "type":"string",
+          "title":"Favorite TV Series",
+            "enum":[
+              "The Big Bang Theory",
+              "Friends",
+              "Grey's Anatomy",
+              "Babylon 5",
+              "Firefly",
+              "The Flinstones"
+            ]
+        },
+        "actor_male":{
+          "type":"string",
+          "title":"Favorite Male Actor",
+          "enum":[
+            "Tom Hanks",
+            "Sean Connery",
+            "Mark Harmon",
+            "Client Eastwood",
+            "Neil Patrick Harris"
+          ]
+        },
+        "actor_female":{
+          "type":"string",
+          "title":"Favorite Female Actor",
+          "enum":[
+            "Emily Blunt",
+            "Julie Andrews",
+            "Meryl Streep",
+            "Helen Mirren"
+          ]
+        }
+      },
+      "form": [
+        {
+          "type":"fieldset",
+          "title":"Example of Tabs",
+          "items":[
+            {
+              "type":"tabs",
+              "id":"navtabs",
+              "items": [
+                {
+                  "title":"Movies",
+                  "type":"tab",
+                  "items":[
+                    {  
+                      "key":"favorite_movie",
+                      "type":"radiobuttons",
+                      "activeClass": "btn-success"
+                    }
+                  ]
+                },
+                {
+                  "title":"TV Series",
+                  "type":"tab",
+                  "items":[
+                    {  
+                      "key":"favorite_tv",
+                      "type":"radiobuttons",
+                      "activeClass": "btn-success"
+                    }
+                  ]
+                },
+                {
+                  "title":"Actors",
+                  "type":"tab",
+                  "items":[
+                    {  
+                      "key":"actor_male",
+                      "type":"radiobuttons",
+                      "activeClass": "btn-success"
+                    },
+                    {  
+                      "key":"actor_female",
+                      "type":"radiobuttons",
+                      "activeClass": "btn-success"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "actions",
+          "items": [
+            {
+              "type": "submit",
+              "value": "Submit"
+            }
+          ]
+        }
+      ]
+}

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -44,7 +44,8 @@ $('document').ready(function () {
           'templating-tpldata',
           'events',
           'previousvalues',
-          'factory-sleek'
+          'factory-sleek',
+          'navigation-tabs'
         ],
         'default': 'gettingstarted'
       },
@@ -98,7 +99,8 @@ $('document').ready(function () {
           'templating-tpldata': 'Templating - Using the tpldata property',
           'events': 'Using event handlers',
           'previousvalues': 'Using previously submitted values',
-          'factory-sleek': 'Joshfire Factory - Sleek template'
+          'factory-sleek': 'Joshfire Factory - Sleek template',
+          'navigation-tabs': 'Display - Navigation tabs'
         },
         onChange: function (evt) {
           var selected = $(evt.target).val();

--- a/tests/other/forms/tabs-nav.js
+++ b/tests/other/forms/tabs-nav.js
@@ -1,0 +1,110 @@
+$("#testform").jsonForm({
+  "schema": {
+    "favorite_movie":{
+      "type":"string",
+      "title":"Favorite Movie",
+      "enum":[
+        "Field of Dreams",
+        "Braveheart",
+        "A League of Their Own"
+      ]
+    },
+    "favorite_tv":{
+      "type":"string",
+      "title":"Favorite TV Series",
+        "enum":[
+          "The Big Bang Theory",
+          "Friends",
+          "Grey's Anatomy",
+          "Babylon 5",
+          "Firefly",
+          "The Flinstones"
+        ]
+    },
+    "actor_male":{
+      "type":"string",
+      "title":"Favorite Male Actor",
+      "enum":[
+        "Tom Hanks",
+        "Sean Connery",
+        "Mark Harmon",
+        "Client Eastwood",
+        "Neil Patrick Harris"
+      ]
+    },
+    "actor_female":{
+      "type":"string",
+      "title":"Favorite Female Actor",
+      "enum":[
+        "Emily Blunt",
+        "Julie Andrews",
+        "Meryl Streep",
+        "Helen Mirren"
+      ]
+    }
+  },
+  "form": [
+    {
+      "type":"fieldset",
+      "title":"Example of Tabs",
+      "items":[
+        {
+          "type":"tabs",
+          "id":"navtabs",
+          "items": [
+            {
+              "title":"Movies",
+              "type":"tab",
+              "items":[
+                {  
+                  "key":"favorite_movie",
+                  "type":"radiobuttons",
+                  "activeClass": "btn-success"
+                }
+              ]
+            },
+            {
+              "title":"TV Series",
+              "type":"tab",
+              "items":[
+                {  
+                  "key":"favorite_tv",
+                  "type":"radiobuttons",
+                  "activeClass": "btn-success"
+                }
+              ]
+            },
+            {
+              "title":"Actors",
+              "type":"tab",
+              "items":[
+                {  
+                  "key":"actor_male",
+                  "type":"radiobuttons",
+                  "activeClass": "btn-success"
+                },
+                {  
+                  "key":"actor_female",
+                  "type":"radiobuttons",
+                  "activeClass": "btn-success"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "actions",
+      "items": [
+        {
+          "type": "submit",
+          "value": "Submit"
+        }
+      ]
+    }
+  ],
+  "onSubmit": function (errors,values) {
+  console.log(errors,values);
+  }
+});

--- a/tests/other/tabs-nav.html
+++ b/tests/other/tabs-nav.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      @import url("../../deps/opt/bootstrap.css");
+    </style>
+  </head>
+  
+  <body>
+    <form id="testform" class="form-vertical"></form>
+
+    <script src="../../deps/jquery.min.js"></script>
+    <script src="../../deps/underscore.js"></script>
+    <script src="../../lib/jsonform.js"></script>
+    <script src="forms/tabs-nav.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This feature is to allow bootstrap navigation tabs to be used to segment form fields onto multiple tabs. 

This commit is to add a new feature: Navigation tabs. Navigation tabs are setup at 2 levels. The first is a type "tabs" that has a unique id and an items array. Each item is a object of type "tab" that has a title, which will be displayed as the tab text, and then items. These items are all of the fields to be presented on this tab.

Test HTML and JS pages have also been created under the tabs-nav namespace. This namespace was choosen so that it would not conflict with other "tab" namespaces that are currently present. It also is informative as it signifies the purpose of the tabs to be navigation, while still keeping the namespace brief.
