### PR TITLE
selectfieldset: fix select style

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -1383,7 +1383,7 @@ jsonform.elementTypes = {
       data.value = activeChild.value;
 
       var elt = node.formElement;
-      var tabs = '<select class="nav"' +
+      var tabs = '<select class="nav form-control"' +
         (node.disabled ? ' disabled' : '') +
         '>';
       _.each(children, function (child, idx) {


### PR DESCRIPTION
Hello

We can see on the selectfieldsetexample (https://jsonform.github.io/jsonform/playground/index.html?example=fields-selectfieldset) that the select field used to perform the selection between the item has not the proper style:

![selectfieldset](https://user-images.githubusercontent.com/6479682/121482830-ca090700-c9cd-11eb-85bf-d05823a55f60.PNG)

To avoid complex style with css stuff, I suggest to add the class "form-control" to the select field generated by the lib. See git diff of this PR.

Tested with my own project OK but I let you check it and verify it has no unwanted impact, I guess there isn't.

Joel