### PR TITLE
Support of simple but nice accept feature on file input

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -499,6 +499,7 @@ jsonform.elementTypes = {
   'file':{
     'template':'<input class="input-file" id="<%= id %>" name="<%= node.name %>" type="file" ' +
       '<%= (node.schemaElement && node.schemaElement.required ? " required=\'required\'" : "") %>' +
+      '<%= (node.formElement && node.formElement.accept ? (" accept=\'" + node.formElement.accept + "\'") : "") %>' +
       '/>',
     'fieldtemplate': true,
     'inputfield': true
@@ -2367,7 +2368,7 @@ formNode.prototype.computeInitialValues = function (values, ignoreDefaultValues)
         if (typeof this.value === 'string') {
           this.value = _.template(this.value, valueTemplateSettings)(formData);
         }
-        
+
       }
     }
     else if (!ignoreDefaultValues) {


### PR DESCRIPTION
Hello,

This PR permit to add the "accept" field to the "file" input.

This field permit to filter on file extension(s) or mime types: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers

"accept" is added to the form, here is a snippet:

```
{
  "key":"the-key",
  "type":"file",
  "accept":".pdf"
}
```

Joel

PS: edition removed some unused spaces L2370