### PR TITLE
playground: add file example with upload in textarea

### DIFF
--- a/playground/examples/fields-file.json
+++ b/playground/examples/fields-file.json
@@ -1,0 +1,38 @@
+{
+  "schema": {
+    "file_content":{
+      "title":"File content",
+      "type":"string"
+    },
+    "upload":{
+      "type":"string"
+    }
+  },
+  "form": [
+    {
+      "key":"file_content",
+      "type":"textarea"
+    },
+    {
+      "key":"upload",
+      "type":"file",
+      "accept":".txt,.md",
+      "notitle":true,
+      "onChange": function (evt, node) {
+        if (evt.target.files[0]) {
+          var reader = new FileReader();
+          reader.onload = function(event) {
+            document.getElementsByName('file_content')[0].value = event.target.result;
+          };
+          reader.readAsText(evt.target.files[0]);
+        } else {
+          document.getElementsByName('file_content')[0].value = '';
+        }
+      }
+    },
+    {
+      "type": "submit",
+      "title": "Submit"
+    }
+  ]
+}

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -39,6 +39,7 @@ $('document').ready(function () {
           'fields-help',
           'fields-hidden',
           'fields-questions',
+          'fields-file',
           'templating-idx',
           'templating-value',
           'templating-values',
@@ -94,6 +95,7 @@ $('document').ready(function () {
           'fields-help': 'Fields - Guide users: the help type',
           'fields-hidden': 'Fields - Hidden form values: the hidden type',
           'fields-questions': 'Fields - Series of questions: the questions type',
+          'fields-file': 'Fields - Upload file: the file type',
           'templating-idx': 'Templating - item index with idx',
           'templating-value': 'Templating - tab legend with value and valueInLegend',
           'templating-values': 'Templating - values.xxx to reference another field',
@@ -137,7 +139,7 @@ $('document').ready(function () {
     for (var i = 0; i < vars.length; i++) {
       param = vars[i].split('=');
       if (param[0] === 'example') {
-        if (param[1].charAt(param[1].length - 1) == '/') 
+        if (param[1].charAt(param[1].length - 1) == '/')
           return param[1].replace('/', '');
         return param[1];
       }


### PR DESCRIPTION
Hello @tchapi 

Here is a file upload example as discussed at https://github.com/jsonform/jsonform/pull/377.

As discussed at https://github.com/jsonform/jsonform/issues/375, there is a workaround to get it working. A field is created in the form just to have the upload button in the form. We can see it's not submitted because it's value doesn't exist ("input" type "file" in html has no value).

Joel