### PR TITLE
add support for value of non-schema selectfieldset items

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -1365,7 +1365,7 @@ jsonform.elementTypes = {
           child.childPos = idx; // When nested the childPos is always 0.
           return {
             title: child.legend || child.title || ('Option ' + (child.childPos+1)),
-            value: choices[child.childPos] || child.childPos,
+            value: choices[child.childPos] || child.value || child.childPos,
             node: child
           };
         });


### PR DESCRIPTION
without this a selectfieldset like this 
```
         {
                  "title":"weatherEndpoint",                
                  "key":"weather.config.weatherEndpoint",
                  "type":"selectfieldset",
                  "items":[
                    {
                      "title":"/forecast",
                      "value":"/forecast"
                    },
                    {
                      "title":"/forecast/daily",
                      "value":"/forecast/daily"
                    },
                    {
                      "title":"/weather",
                      "value":"/weather"
                    },
                    {
                      "title":"/onecall",
                      "value":"/onecall"
                    }
                  ]
                },
```

will return 0, 1, 2, or 3 for the choices
title is used, but value was not

fixes #388 