### PR TITLE
enhance selectfieldset onchange handler and onInsert to allow for embedded selectfieldsets

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -1413,10 +1413,25 @@ jsonform.elementTypes = {
       return data;
     },
     'onInsert': function (evt, node) {
-      $(node.el).find('select.nav').first().on('change', function (evt) {
-        var $option = $(this).find('option:selected');
-        $(node.el).find('input[type="hidden"]').first().val($option.attr('value'));
-      });
+      // make the handler in a separate function
+      // as we may be calling multiple times to attach it to different elements
+      var selectchg=function (evt) {
+        // use the event to locate the option
+        var $option = $(evt.currentTarget).find('option:selected');
+        // use the event to locate our parent fieldset, and the hidden inut field under it
+        $(evt.currentTarget).closest("fieldSet").find('input[type="hidden"]').first().val($option.attr('value'));
+      };
+      // find all select elements with class nav and NOT already linked
+      // bound class means we have a handler there already, don't double up
+      var x=$(node.el).find('select.nav:not(.bound)');
+      // loop thru all the elements found
+      // this handles selectfieldset in selectefieldset
+      // the parent will see the child, even if its not the first
+      // choice in the child selectfieldset
+      for (let s of x){
+          // add the bound class and the handler
+          $(s).addClass('bound').on('change',selectchg)
+      }
     }
   },
   'optionfieldset': {


### PR DESCRIPTION
instead of only first select clause, attach to all (child may be not active on insert, so handler not setup)
add marker (class) to make sure we don't double attach change handler
fixes #389 