### PR TITLE
Datalist for input fields

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -257,6 +257,7 @@ var inputFieldTemplate = function (type) {
   return {
     'template': '<input type="' + type + '" ' +
       'class=\'form-control<%= (fieldHtmlClass ? " " + fieldHtmlClass : "") %>\'' +
+      ' <%= (datalist ? "list=\'" + datalist + "\' " : "") %>' +
       'name="<%= node.name %>" value="<%= escape(value) %>" id="<%= id %>"' +
       ' aria-label="<%= node.title ? escape(node.title) : node.name %>"' +
       '<%= (node.disabled? " disabled" : "")%>' +
@@ -2847,6 +2848,18 @@ formNode.prototype.generate = function () {
   if (this.formElement &&
       (typeof this.formElement.fieldHtmlClass !== 'undefined')) {
     data.fieldHtmlClass = this.formElement.fieldHtmlClass;
+  }
+
+  data.datalist = '';
+  if (this.ownerTree &&
+      this.ownerTree.formDesc &&
+      this.ownerTree.formDesc.params &&
+      this.ownerTree.formDesc.params.dataList) {
+    data.datalist = this.ownerTree.formDesc.params.datalist;
+  }
+  if (this.formElement &&
+      (typeof this.formElement.datalist !== 'undefined')) {
+    data.datalist = this.formElement.datalist;
   }
 
   // Apply the HTML template


### PR DESCRIPTION
Now supports autocomplete for input fields via datalists. 

Previously, this was only possible by some dirty workaround like e.g.
```
{
  "schema": {
    "city": {
      "type": "string",
      "title": "City"
    }
  },
  "form": [
    {
      "key": "city",
      "fieldHtmlClass": "'list=cityname name='city'",
      "append": "<datalist id='cityname'><option value='Bochum'><option value='Berlin'></datalist>"
    }
  ]
}
```
Now, the same behaviour can be achieved by
```
{
  "schema": {
    "city": {
      "type": "string",
      "title": "City"
    }
  },
  "form": [
    {
      "key": "city",
      "datalist": "cityname",
      "append": "<datalist id='cityname'><option value='Bochum'><option value='Berlin'></datalist>"
    }
  ]
}
```