### PR TITLE
Add support for number text inputs' maximum and minumum attributes

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -265,6 +265,8 @@ var inputFieldTemplate = function (type) {
       '<%= (node.schemaElement && node.schemaElement.minLength ? " minlength=\'" + node.schemaElement.minLength + "\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.maxLength ? " maxlength=\'" + node.schemaElement.maxLength + "\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.required && (node.schemaElement.type !== "boolean") ? " required=\'required\'" : "") %>' +
+      '<%= (node.schemaElement && (node.schemaElement.type === "number") && !isNaN(node.schemaElement.maximum) ? " max=" + \'"\' + node.schemaElement.maximum + \'"\' : "")%>' +
+      '<%= (node.schemaElement && (node.schemaElement.type === "number") && !isNaN(node.schemaElement.minimum) ? " min=" + \'"\' + node.schemaElement.minimum + \'"\' : "")%>' +
       '<%= (node.placeholder? " placeholder=" + \'"\' + escape(node.placeholder) + \'"\' : "")%>' +
       ' />',
     'fieldtemplate': true,


### PR DESCRIPTION
Add support for json-schema number's `maximum` and `minimum` fields, mapping them to the text-input's `max` and `min` tags respectively. 

These fields are already enforced by schema validation, but the input fields allowing you to input out-of-bounds numbers can be confusing, and validation errors are not differentiated from description fields if you don't have separate CSS for `help-block` and `jsonform-errortext`.  